### PR TITLE
Allow ignore=pattern definitions in .wakatime.conf to ignore files

### DIFF
--- a/wakatime/__init__.py
+++ b/wakatime/__init__.py
@@ -75,6 +75,8 @@ def parseArguments(argv):
     parser.add_argument('--key', dest='key',
             help='your wakati.me api key; uses api_key from '+
                 '~/.wakatime.conf by default')
+    parser.add_argument('--ignore', dest='ignore', action='append',
+            help='filename patterns to ignore for reporting')
     parser.add_argument('--logfile', dest='logfile',
             help='defaults to ~/.wakatime.log')
     parser.add_argument('--config', dest='config',
@@ -83,49 +85,35 @@ def parseArguments(argv):
             help='turns on debug messages in log file')
     parser.add_argument('--version', action='version', version=__version__)
     args = parser.parse_args(args=argv[1:])
+    parse_config(args)
     if not args.timestamp:
         args.timestamp = time.time()
-    if not args.key:
-        default_key = get_api_key(args.config)
-        if default_key:
-            args.key = default_key
-        else:
-            parser.error('Missing api key')
     return args
 
 
-def get_api_key(configFile):
-    if not configFile:
-        configFile = os.path.join(os.path.expanduser('~'), '.wakatime.conf')
-    api_key = None
+def parse_config(args):
+    if not args.config:
+        args.config = os.path.join(os.path.expanduser('~'), '.wakatime.conf')
     try:
-        cf = open(configFile)
+        cf = open(args.config)
         for line in cf:
             line = line.split('=', 1)
+            line[0] = line[0].strip()
             if line[0] == 'api_key':
-                api_key = line[1].strip()
+                if args.key is None:
+                    args.key = line[1].strip()
+            elif line[0] == 'logfile':
+                if args.logfile is None:
+                    args.logfile = line[1].strip()
+            elif line[0] == 'verbose':
+                args.verbose = True
+            elif line[0] == 'ignore':
+                if args.ignore is None:
+                    args.ignore = []
+                args.ignore.append(line[1].strip())
         cf.close()
     except IOError:
         print('Error: Could not read from config file.')
-    return api_key
-
-
-# TODO merge these into a single config file parsing routine, probably allow
-# any of the command line args to be specified that are reasonable
-def get_ignores(configFile):
-    if not configFile:
-        configFile = os.path.join(os.path.expanduser('~'), '.wakatime.conf')
-    ignore = []
-    try:
-        cf = open(configFile)
-        for line in cf:
-            line = line.split('=', 1)
-            if line[0] == 'ignore':
-                ignore.append(re.compile(line[1].strip()))
-        cf.close()
-    except IOError:
-        print('Error: Could not read from config file.')
-    return ignore
 
 
 def get_user_agent(plugin):
@@ -209,10 +197,9 @@ def main(argv=None):
     setup_logging(args, __version__)
     if os.path.isfile(args.targetFile):
         log.debug('Checking file %s against ignores' % args.targetFile)
-        ignore = get_ignores(args.config)
-        for item in ignore:
-            if item.search(args.targetFile):
-                log.debug('File matches %s, not reporting' % item.pattern)
+        for item in args.ignore:
+            if re.search(item, args.targetFile):
+                log.debug('File matches %s, not reporting' % item)
                 return 103
 
         branch = None


### PR DESCRIPTION
Wakatime is forever reporting my emails as /tmp/mutt-blahblahblah and I personally don't care to be reminded how many and what number of emails I had to send so I added this to let me include ignore patterns in the config file (e.g. `ignore=/tmp/mutt-.*`).

As mentioned in the TODO comment the config parsing code is duplicated and should probably be merged into a single one but I didn't have time to do that yet and it seemed like a separate issue.

EDIT:  I have now restructured it to allow --ignore patterns on the command line and added some additional options to the config file that were available as command line options (namely --logfile and --verbose).  Now there is only one pass to parse the config file.  Options from the command line are given precedence over those in the config file, but the ignore patterns are merged.
